### PR TITLE
Support for loading .env in a different directory

### DIFF
--- a/lib/vagrant-env/config.rb
+++ b/lib/vagrant-env/config.rb
@@ -3,11 +3,33 @@ require 'dotenv'
 module VagrantPlugins
   module Env
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :enable
-      def initialize
-        @enable = UNSET_VALUE
-        Dotenv.load
+
+      # Simple interface:
+      # config.env.enable __FILE__
+      def enable(vagrantfile = nil)
+        if vagrantfile
+          load File.dirname(vagrantfile) + '/.env'
+        else
+          # The default is .env in the current directory - but that may not be
+          # the same directory that the Vagrantfile is in
+          # https://github.com/gosuri/vagrant-env/issues/2
+          load
+        end
       end
+
+      # Lower-level methods - proxy to Dotenv:
+      def load(*filenames)
+        Dotenv::load *filenames
+      end
+
+      def load!(*filenames)
+        Dotenv::load! *filenames
+      end
+
+      def overload(*filenames)
+        Dotenv::overload *filenames
+      end
+
     end
   end
 end


### PR DESCRIPTION
About five minutes after submitting issue #2 I worked out a solution! This should fix both #2 and #1.

This changes the recommended plugin usage from:

``` ruby
config.env.enable
```

To:

``` ruby
config.env.enable __FILE__
```

I'd prefer not to have to do that, but I can't work out how to get the path to the Vagrantfile. (Maybe someone with better knowledge of Vagrant internals can fix that...) In the mean time, the original method (with no parameters) will still work and still have the same effect it used to - looking in the current working directory instead of the Vagrantfile directory.

I also added three low-level methods to allow the user to call Dotenv methods directly:

``` ruby
config.env.load '/path/to/.anotherenv'
config.env.load! '/path/to/.env'
config.env.overload '/path/to/.env'
```

See the [dotenv source comments](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv.rb) for explanations of these three methods. (They don't seem to be documented anywhere else...) Note that these paths are relative to the current working directory, so `File.dirname(__FILE__)` may be called for here.
