### PR TITLE
Fixes for newer Vagrant versions that bundle with newer Ruby versions

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -1,0 +1,31 @@
+name: Release Ruby Gem
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+    
+    - name: Build gem
+      run: |
+        gem build *.gemspec
+    
+    - name: Upload gem to release
+      run: |
+        gem_file=$(ls *.gem | head -n 1)
+        gh release upload ${{ github.event.release.tag_name }} $gem_file
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 *.a
 mkmf.log
 .vagrant
+.envrc
+.direnv
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .envrc
 .direnv
 .idea
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in vagrant-env.gemspec
-gemspec
+
 
 group :development do
   gem "vagrant", git: "https://github.com/mitchellh/vagrant.git"
-  gem 'rake', '~> 10.0'
+  gem 'rake', '= 13.0.6'
 end
 
 group :plugins do
-  gem "vagrant-env", path: "."
+  gemspec
 end

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ $ vagrant plugin install vagrant-env
 
 To install an older version of the plugin use `vagrant plugin install vagrant-env --plugin-version VERSION`
 
+## Building and installing from source
+```sh
+git clone https://github.com/Meantub/vagrant-env.git
+cd ./vagrant-env
+gem build vagrant-env.gemspec
+vagrant plugin install ./vagrant-env-{VERSION}.gem
+```
+
 ## Usage
 
 After installing, add your application configuration to your .env file in the root of your project

--- a/lib/vagrant-env/version.rb
+++ b/lib/vagrant-env/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Env
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end

--- a/lib/vagrant-env/version.rb
+++ b/lib/vagrant-env/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Env
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/vagrant-env.gemspec
+++ b/vagrant-env.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
                       lib/vagrant-env/config.rb
                       lib/vagrant-env/plugin.rb)
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency     "dotenv", "~> 0.9"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_runtime_dependency     "dotenv", "= 2.8.1"
+  spec.add_development_dependency "bundler", "= 2.4.10"
 end

--- a/vagrant-env.gemspec
+++ b/vagrant-env.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
                       lib/vagrant-env/plugin.rb)
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency     "dotenv", "= 2.8.1"
-  spec.add_development_dependency "bundler", "= 2.4.10"
+  spec.add_development_dependency "bundler", "= 2.4.19"
 end


### PR DESCRIPTION
Hello this is a fix for #15, if this repo isn't stale I figured I'd put this out there just in case the person that maintains this sees this and wants to fix it.

If not then you can use my fork to fix this for newer versions of Vagrant.